### PR TITLE
openapiとrack-cors導入

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,6 @@
     // VSCodeのルートディレクトリ
     "workspaceFolder": "/ruby_app",
     // コンテナからホストに転送するポートリスト
-    "forwardPorts": [3000],
+    "forwardPorts": [3000]
     // ここまでの参考: https://qiita.com/75ks/items/b2961e8562c353f42d21
 }

--- a/Gemfile
+++ b/Gemfile
@@ -54,3 +54,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.8)
+    rack-cors (2.0.1)
+      rack (>= 2.0.0)
     rack-mini-profiler (2.3.4)
       rack (>= 1.2.0)
     rack-proxy (0.7.7)
@@ -233,6 +235,7 @@ DEPENDENCIES
   listen (~> 3.3)
   mysql2 (~> 0.5)
   puma (~> 5.0)
+  rack-cors
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.0)
   sass-rails (>= 6)

--- a/app/controllers/health_check_controller.rb
+++ b/app/controllers/health_check_controller.rb
@@ -1,0 +1,6 @@
+class HealthCheckController < ApplicationController
+
+    def show
+        render json: {message: "OK"}, status: :ok
+    end
+end

--- a/compose.yml
+++ b/compose.yml
@@ -17,5 +17,24 @@ services:
       - "3000:3000"
     volumes:
       - .:/ruby_app
+
+  swagger-editor:
+    image: swaggerapi/swagger-editor
+    ports:
+      - "8000:8080"
+    volumes:
+      - ./docs/openapi.yaml:/tmp/openapi.yaml
+    environment:
+      SWAGGER_FILE: /tmp/openapi.yaml
+
+  swagger-ui:
+    image: swaggerapi/swagger-ui
+    ports: 
+      - "8001:8080"
+    volumes:
+      - ./docs/openapi.yaml:/usr/share/nginx/html/openapi.yaml
+    environment:
+      API_URL: openapi.yaml
+
 volumes:
   db-data:

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,11 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+    unless Rails.env.production?
+      allow do
+        origins(['localhost', /localhost:\d+\Z/])
+  
+        resource '*',
+          headers: :any,
+          methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      end
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   post '/users/login', to: 'user#login'
   get '/users/me', to: 'user#show'
   put '/users/me', to: 'user#edit'
+  get '/healthz', to: 'health_check#show'
 end

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.3
+info:
+  title: ruby_app
+  version: 1.0.0
+servers:
+  - url: http://localhost:3000
+tags:
+  - name: HealthChecks
+    description: Endpoint to do healthchecks
+paths:
+  /healthz:
+    get:
+      tags:
+        - HealthChecks
+      summary: get success response
+      operationId: healthCheck
+      responses:
+        '200':
+          description: return result ok
+          content:
+            application/json:
+              schema:
+                required:
+                  - result
+                type: object
+                properties:
+                 result:
+                  type: string
+                  example: ok


### PR DESCRIPTION
### 概要
- openapiを導入。
- health check用エンドポイント`/healthz`を追加。
- openapi.yamlに/healthzのスキーマを記載。
- swaggerからAPIにリクエストが送れるように`rack-cors`を導入し、`cors.rb`を作成。