### PR TITLE
GET /posts/idを実装

### DIFF
--- a/app/controllers/post_controller.rb
+++ b/app/controllers/post_controller.rb
@@ -16,6 +16,13 @@ class PostController < ApplicationController
         render json: posts
     end
 
+    def show
+        post = Post.find(params[:id])
+        render json: post
+    rescue ActiveRecord::RecordNotFound
+        render json: { error: "Post not found" }, status: :not_found
+    end
+
     private
 
     def post_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get '/healthz', to: 'health_check#show'
   post '/posts', to: 'post#create'
   get '/posts', to: 'post#index'
+  get '/posts/:id', to: 'post#show'
   # 本当はresourcesを使った書き方の方がいいらしいが、今回の実装ではcontroller名がpostなのでエンドポイント名も/postになってしまうのでコメントアウト。
   # resources :post, only: [:index]
 end


### PR DESCRIPTION
### 概要
idを指定して記事を取得する、`GET /posts/id`を実装した。
指定したidの記事が見つからない場合は404が返る。